### PR TITLE
metallb: add k8s 1.24 annotations

### DIFF
--- a/system/network/nginx-external/values.yaml
+++ b/system/network/nginx-external/values.yaml
@@ -52,16 +52,17 @@ ingress-nginx:
             app.kubernetes.io/name: nginx-external
     service:
       enabled: true
+      loadBalancerIP: &IP "192.168.1.249"
 
-      annotations: {}
+      annotations:
+        metallb.universe.tf/loadBalancerIPs: *IP
+
       labels: {}
 
       ## List of IP addresses at which the controller services are available
       ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
       ##
       externalIPs: []
-
-      loadBalancerIP: "192.168.1.249"
 
       enableHttp: true
       enableHttps: true

--- a/system/network/nginx-internal/values.yaml
+++ b/system/network/nginx-internal/values.yaml
@@ -51,16 +51,17 @@ ingress-nginx:
             app.kubernetes.io/name: nginx-internal
     service:
       enabled: true
+      loadBalancerIP: &IP "192.168.1.250"
 
-      annotations: {}
+      annotations:
+        metallb.universe.tf/loadBalancerIPs: *IP
+
       labels: {}
 
       ## List of IP addresses at which the controller services are available
       ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
       ##
       externalIPs: []
-
-      loadBalancerIP: "192.168.1.250"
 
       enableHttp: true
       enableHttps: true


### PR DESCRIPTION
k8s 1.24 annotations because loadBalancerIP possible deprecation in future API

https://github.com/Azure/AKS/issues/3122

Service.spec.loadBalancerIP https://github.com/kubernetes/kubernetes/pull/107235. From the [Change Log](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#deprecation):

    Deprecated Service.Spec.LoadBalancerIP. This field was under-specified and its meaning varies across implementations. As of Kubernetes v1.24, users are encouraged to use implementation-sp